### PR TITLE
Fix file input not allowing reupload

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,13 +37,20 @@ class SpinToSpeak {
     }
 
     handleFileUpload(event) {
-        const file = event.target.files[0];
+        const input = event.target;
+        const file = input.files[0];
         if (!file) return;
 
         const reader = new FileReader();
         reader.onload = (e) => {
             const csv = e.target.result;
             this.parseCSV(csv);
+
+            // Clear the input so uploading the same file again triggers
+            // the change event. This improves usability when users want to
+            // reload an updated participant list without selecting a
+            // different file first.
+            input.value = '';
         };
         reader.readAsText(file);
     }


### PR DESCRIPTION
## Summary
- allow re-uploading the same CSV after initial selection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68746c89eac0832f94831a35f51a5428